### PR TITLE
Task2

### DIFF
--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -3,7 +3,7 @@
 # Based on https://github.com/yeputons/project-templates
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
-SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
+SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
 SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -3,7 +3,7 @@
 # Based on https://github.com/yeputons/project-templates
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
-SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/protocol.cpp
+SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
 SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -21,7 +21,7 @@ bin/server32: $(SRCS_server:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o32)
 bin/server: $(SRCS_server:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o64)
 
 CXX=g++
-CXXFLAGS=-pthread -pedantic -Wall -Wshadow -Wextra -Werror -std=c++11 -I$(INCDIR)
+CXXFLAGS=-pthread -pedantic -Wall -Wshadow -Wextra -Werror -std=c++11 -I$(INCDIR) -g
 LDFLAGS=-pthread
 LDLIBS=
 ifeq ($(OS),Windows_NT)

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -3,7 +3,7 @@
 # Based on https://github.com/yeputons/project-templates
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
-SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
+SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
 SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -4,7 +4,7 @@
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
 SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
-SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp
+SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp
 OBJDIR=.obj

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -3,7 +3,7 @@
 # Based on https://github.com/yeputons/project-templates
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
-SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
+SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
 SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -3,8 +3,8 @@
 # Based on https://github.com/yeputons/project-templates
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
-SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
-SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp $(SRCDIR)/test_locking_queue.cpp
+SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp $(SRCDIR)/retrier.cpp
+SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp $(SRCDIR)/test_locking_queue.cpp $(SRCDIR)/test_retrier.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp
 OBJDIR=.obj

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -4,7 +4,7 @@
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
 SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
-SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp $(SRCDIR)/test_locking_char_queue.cpp
+SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp $(SRCDIR)/test_locking_queue.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp
 OBJDIR=.obj

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -22,6 +22,7 @@ bin/server: $(SRCS_server:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o64)
 
 CXX=g++
 CXXFLAGS=-pthread -pedantic -Wall -Wshadow -Wextra -Werror -std=gnu++11 -I$(INCDIR) -g
+#CXXFLAGS+=-DAU_DEBUG
 LDFLAGS=-pthread
 LDLIBS=
 LDLIBS_TEST=-lgtest -lgtest_main

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -4,7 +4,7 @@
 
 TARGETS=bin/test32 bin/test64 bin/client32 bin/client64 bin/server32 bin/server
 SRCS_common=$(SRCDIR)/tcp_socket.cpp $(SRCDIR)/au_stream_socket.cpp $(SRCDIR)/au_stream_socket_impl.cpp $(SRCDIR)/au_stream_socket_protocol.cpp $(SRCDIR)/common_socket_impl.cpp $(SRCDIR)/protocol.cpp
-SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp
+SRCS_test=$(SRCS_common) $(SRCDIR)/test.cpp $(SRCDIR)/test_protocol.cpp $(SRCDIR)/test_cyclic_queue.cpp $(SRCDIR)/test_locking_char_queue.cpp
 SRCS_client=$(SRCS_common) $(SRCDIR)/client.cpp
 SRCS_server=$(SRCS_common) $(SRCDIR)/server.cpp
 OBJDIR=.obj

--- a/task1-2/Makefile
+++ b/task1-2/Makefile
@@ -21,13 +21,20 @@ bin/server32: $(SRCS_server:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o32)
 bin/server: $(SRCS_server:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o64)
 
 CXX=g++
-CXXFLAGS=-pthread -pedantic -Wall -Wshadow -Wextra -Werror -std=c++11 -I$(INCDIR) -g
+CXXFLAGS=-pthread -pedantic -Wall -Wshadow -Wextra -Werror -std=gnu++11 -I$(INCDIR) -g
 LDFLAGS=-pthread
 LDLIBS=
+LDLIBS_TEST=-lgtest -lgtest_main
 ifeq ($(OS),Windows_NT)
   CXXFLAGS+=-DWINVER=WindowsXP
   LDLIBS+=-lws2_32
 endif
+
+bin/test32: | bin
+	$(CXX) -m32 -o $@ $(LDFLAGS) $^ $(LDLIBS) $(LDLIBS_TEST)
+
+bin/test64: | bin
+	$(CXX) -m64 -o $@ $(LDFLAGS) $^ $(LDLIBS) $(LDLIBS_TEST)
 
 bin/%32: | bin
 	$(CXX) -m32 -o $@ $(LDFLAGS) $^ $(LDLIBS)

--- a/task1-2/inc/au_stream_addr_map.h
+++ b/task1-2/inc/au_stream_addr_map.h
@@ -1,6 +1,7 @@
 #ifndef AU_STREAM_ADDR_MAP_
 #define AU_STREAM_ADDR_MAP_
 
+#include <iostream>
 namespace au_stream_socket {
 
 struct sockaddr_in_cmp {
@@ -45,14 +46,19 @@ public:
   iterator find(sockaddr_in addr) {
     assert(addr.sin_family == AF_INET);
     auto it = data_.lower_bound(addr);
-    if (it == data_.end() || it->first.sin_port != addr.sin_port) {
-      return data_.end();
-    }
-    if (it->first.sin_addr.s_addr == 0 || addr.sin_addr.s_addr == 0) {
+    if (it != data_.end() && it->first.sin_port == addr.sin_port &&
+        (it->first.sin_addr.s_addr == 0 || it->first.sin_addr.s_addr == addr.sin_addr.s_addr)) {
       return it;
-    } else {
-      return data_.end();
     }
+    if (addr.sin_addr.s_addr != 0) {
+      sockaddr_in to_find = addr;
+      to_find.sin_addr.s_addr = 0;
+      it = data_.find(to_find);
+      if (it != data_.end()) {
+        return it;
+      }
+    }
+    return data_.end();
   }
 
 private:

--- a/task1-2/inc/au_stream_addr_map.h
+++ b/task1-2/inc/au_stream_addr_map.h
@@ -1,0 +1,64 @@
+#ifndef AU_STREAM_ADDR_MAP_
+#define AU_STREAM_ADDR_MAP_
+
+namespace au_stream_socket {
+
+struct sockaddr_in_cmp {
+  bool operator()(const sockaddr_in &a, const sockaddr_in &b) const {
+    assert(a.sin_family == AF_INET);
+    assert(b.sin_family == AF_INET);
+    if (a.sin_port != b.sin_port) {
+      return a.sin_port < b.sin_port;
+    }
+    return a.sin_addr.s_addr < b.sin_addr.s_addr;
+  }
+};
+
+template<typename T>
+class addr_map {
+private:
+  typedef std::map<sockaddr_in, T, sockaddr_in_cmp> inner_map;
+
+public:
+  typedef typename inner_map::iterator iterator;
+
+  iterator begin() { return data_.begin(); }
+  iterator end() { return data_.end(); }
+  bool contains(sockaddr_in addr) { return find(addr) != end(); }
+
+  void insert(sockaddr_in addr, T value) {
+    data_.insert(std::make_pair(addr, value));
+  }
+
+  void erase(iterator it) {
+    data_.erase(it);
+  }
+
+  T& operator[](sockaddr_in addr) {
+    auto it = find(addr);
+    if (it == data_.end()) {
+      return data_[addr];
+    }
+    return it->second;
+  }
+
+  iterator find(sockaddr_in addr) {
+    assert(addr.sin_family == AF_INET);
+    auto it = data_.lower_bound(addr);
+    if (it == data_.end() || it->first.sin_port != addr.sin_port) {
+      return data_.end();
+    }
+    if (it->first.sin_addr.s_addr == 0 || addr.sin_addr.s_addr == 0) {
+      return it;
+    } else {
+      return data_.end();
+    }
+  }
+
+private:
+  std::map<sockaddr_in, T, sockaddr_in_cmp> data_;
+};
+
+}  // namespace au_stream_socket
+
+#endif

--- a/task1-2/inc/au_stream_socket.h
+++ b/task1-2/inc/au_stream_socket.h
@@ -8,23 +8,27 @@
 
 typedef uint16_t au_stream_port;
 
-class au_stream_socket_data;
+namespace au_stream_socket {
+class connection_impl;
+class listener_impl;
+}
 
 class au_stream_connection_socket : public stream_socket {
 public:
   au_stream_connection_socket() {}
+  au_stream_connection_socket(std::shared_ptr<au_stream_socket::connection_impl> impl) : impl_(impl) {}
   au_stream_connection_socket(au_stream_connection_socket &&other) = default;
   au_stream_connection_socket& operator=(au_stream_connection_socket &&other) = default;
   ~au_stream_connection_socket() override;
 
-  bool bind(au_stream_port port);
+  explicit operator bool();
   void send(const void *buf, size_t size) override;
   void recv(void *buf, size_t size) override;
 
 private:
   au_stream_connection_socket(const au_stream_connection_socket &) = delete;
 
-  std::weak_ptr<au_stream_socket_data> impl_;
+  std::shared_ptr<au_stream_socket::connection_impl> impl_;
 };
 
 class au_stream_client_socket : public stream_client_socket {
@@ -33,8 +37,8 @@ public:
   ~au_stream_client_socket() override {};
 
   void connect() override;
-  void send(const void *buf, size_t size) override { sock_.send(buf, size); }
-  void recv(void *buf, size_t size) override { sock_.recv(buf, size); }
+  void send(const void *buf, size_t size) override;
+  void recv(void *buf, size_t size) override;
 
 private:
   std::string host_;
@@ -54,7 +58,7 @@ public:
 private:
   au_stream_server_socket(const au_stream_server_socket &) = delete;
 
-  std::weak_ptr<au_stream_socket_data> impl_;
+  std::shared_ptr<au_stream_socket::listener_impl> impl_;
 };
 
 typedef const char* hostname;

--- a/task1-2/inc/au_stream_socket.h
+++ b/task1-2/inc/au_stream_socket.h
@@ -1,0 +1,62 @@
+#ifndef AU_STREAM_SOCKET_H_
+#define AU_STREAM_SOCKET_H_
+
+#include <stdint.h>
+#include <string>
+#include <memory>
+#include "stream_socket.h"
+
+typedef uint16_t au_stream_port;
+
+class au_stream_socket_data;
+
+class au_stream_connection_socket : public stream_socket {
+public:
+  au_stream_connection_socket() {}
+  au_stream_connection_socket(au_stream_connection_socket &&other) = default;
+  au_stream_connection_socket& operator=(au_stream_connection_socket &&other) = default;
+  ~au_stream_connection_socket() override;
+
+  bool bind(au_stream_port port);
+  void send(const void *buf, size_t size) override;
+  void recv(void *buf, size_t size) override;
+
+private:
+  au_stream_connection_socket(const au_stream_connection_socket &) = delete;
+
+  std::weak_ptr<au_stream_socket_data> impl_;
+};
+
+class au_stream_client_socket : public stream_client_socket {
+public:
+  au_stream_client_socket(hostname host, au_stream_port client_port, au_stream_port server_port);
+  ~au_stream_client_socket() override {};
+
+  void connect() override;
+  void send(const void *buf, size_t size) override { sock_.send(buf, size); }
+  void recv(void *buf, size_t size) override { sock_.recv(buf, size); }
+
+private:
+  std::string host_;
+  au_stream_port client_port_, server_port_;
+  au_stream_connection_socket sock_;
+};
+
+class au_stream_server_socket : public stream_server_socket {
+public:
+  au_stream_server_socket(hostname host, au_stream_port port);
+  au_stream_server_socket(au_stream_server_socket &&other) = default;
+  au_stream_server_socket& operator=(au_stream_server_socket &&other) = default;
+  ~au_stream_server_socket() override;
+
+  stream_socket* accept_one_client() override;
+
+private:
+  au_stream_server_socket(const au_stream_server_socket &) = delete;
+
+  std::weak_ptr<au_stream_socket_data> impl_;
+};
+
+typedef const char* hostname;
+
+#endif  // AU_STREAM_SOCKET_H_

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -41,8 +41,8 @@ private:
   }
 
   void process_packet(const au_packet &packet);
-  void add_connection_locked(std::shared_ptr<connection_impl> sock);
-  void remove_connection_locked(sockaddr_in local, sockaddr_in remote);
+  void add_connection_lock_held(std::shared_ptr<connection_impl> sock);
+  void remove_connection_lock_held(sockaddr_in local, sockaddr_in remote);
 
   std::thread thread_;
   std::mutex mutex_;

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -33,7 +33,7 @@ public:
   void stop_listen(sockaddr_in addr);
 
   void add_connection(std::shared_ptr<connection_impl> sock);
-  void remove_connection(sockaddr_in local, sockaddr_in remote);
+  void remove_connection_from_process_packet(sockaddr_in local, sockaddr_in remote);
 
 private:
   messages_broker() : thread_(&messages_broker::run, this) {
@@ -42,7 +42,6 @@ private:
 
   void process_packet(au_packet packet);
   void add_connection_lock_held(std::shared_ptr<connection_impl> sock);
-  void remove_connection_lock_held(sockaddr_in local, sockaddr_in remote);
 
   std::thread thread_;
   std::mutex mutex_;
@@ -73,7 +72,10 @@ enum connection_state {
   CLOSED,
   SYN_SENT,
   SYN_RECV,
-  ESTABLISHED
+  ESTABLISHED,
+  FIN_SENT,
+  FIN_RECV,
+  TERMINATED
 };
 
 class connection_impl {

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -100,8 +100,8 @@ private:
   uint32_t ack_sn;
 
   cyclic_queue<char, uint32_t, 4096> send_window;
-  locking_queue<char, 4096> send_queue;
-  locking_queue<char, 4096> recv_queue;
+  locking_queue<char, uint32_t, 4096> send_queue;
+  locking_queue<char, uint32_t, 4096> recv_queue;
 };
 
 }  // namespace au_stream_socket

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -10,6 +10,7 @@
 #include "au_stream_socket.h"
 #include "common_socket_impl.h"
 #include "au_stream_addr_map.h"
+#include "au_stream_socket_protocol.h"
 
 namespace au_stream_socket {
 
@@ -85,12 +86,13 @@ public:
   void shutdown();
 
 private:
-  void send_packet(Flags flags, const std::vector<bool> data);
+  void send_packet(Flags flags, const std::vector<char> data);
 
   SOCKET sock_;
   sockaddr_in local_, remote_;
   connection_state state_;
   uint32_t send_sn, recv_sn;
+  std::mutex mutex_;
 };
 
 }  // namespace au_stream_socket

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -14,6 +14,7 @@
 #include "utils/cyclic_queue.h"
 #include "utils/locking_queue.h"
 #include "utils/event.h"
+#include "utils/retrier.h"
 
 namespace au_stream_socket {
 
@@ -99,6 +100,7 @@ private:
   void send_some_data(Flags flags);
 
   std::mutex mutex_;
+  retrier retrier_;
 
   SOCKET sock_;
   sockaddr_in local_, remote_;

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -105,8 +105,8 @@ private:
   connection_state state_;
   uint32_t ack_sn;
 
-  locking_queue<char, uint32_t, 4096> send_window;
-  locking_queue<char, uint32_t, 4096> recv_queue;
+  locking_queue<char, uint32_t, 20 * 1024> send_window;
+  locking_queue<char, uint32_t, 20 * 1024> recv_queue;
 };
 
 }  // namespace au_stream_socket

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -92,6 +92,8 @@ public:
 private:
   void send_packet(Flags flags, uint32_t sn, const std::vector<char> data);
 
+  std::mutex mutex_;
+
   SOCKET sock_;
   sockaddr_in local_, remote_;
   connection_state state_;
@@ -100,8 +102,6 @@ private:
   cyclic_queue<char, uint32_t, 4096> send_window;
   locking_queue<char, 4096> send_queue;
   locking_queue<char, 4096> recv_queue;
-
-  std::mutex mutex_;
 };
 
 }  // namespace au_stream_socket

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -90,7 +90,7 @@ public:
   void shutdown();
 
 private:
-  void send_packet(Flags flags, uint32_t sn, const std::vector<char> data);
+  void send_packet(Flags flags, uint32_t sn, std::vector<char> data);
 
   std::mutex mutex_;
 

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -13,6 +13,7 @@
 #include "au_stream_socket_protocol.h"
 #include "utils/cyclic_queue.h"
 #include "utils/locking_queue.h"
+#include "utils/event.h"
 
 namespace au_stream_socket {
 
@@ -24,6 +25,7 @@ class messages_broker {
 public:
   static messages_broker& get() {
     static messages_broker p;
+    p.initialized.await();
     return p;
   }
 
@@ -43,6 +45,7 @@ private:
   void process_packet(au_packet packet);
   void add_connection_lock_held(std::shared_ptr<connection_impl> sock);
 
+  event initialized;
   std::thread thread_;
   std::mutex mutex_;
   addr_map<std::shared_ptr<listener_impl>> listeners_;

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -91,6 +91,7 @@ public:
 
 private:
   void send_packet(Flags flags, uint32_t sn, std::vector<char> data);
+  void send_some_data(Flags flags);
 
   std::mutex mutex_;
 
@@ -99,8 +100,7 @@ private:
   connection_state state_;
   uint32_t ack_sn;
 
-  cyclic_queue<char, uint32_t, 4096> send_window;
-  locking_queue<char, uint32_t, 4096> send_queue;
+  locking_queue<char, uint32_t, 4096> send_window;
   locking_queue<char, uint32_t, 4096> recv_queue;
 };
 

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -12,7 +12,7 @@
 #include "au_stream_addr_map.h"
 #include "au_stream_socket_protocol.h"
 #include "utils/cyclic_queue.h"
-#include "utils/locking_char_queue.h"
+#include "utils/locking_queue.h"
 
 namespace au_stream_socket {
 
@@ -98,8 +98,8 @@ private:
   uint32_t ack_sn;
 
   cyclic_queue<char, uint32_t, 4096> send_window;
-  locking_char_queue<4096> send_queue;
-  locking_char_queue<4096> recv_queue;
+  locking_queue<char, 4096> send_queue;
+  locking_queue<char, 4096> recv_queue;
 
   std::mutex mutex_;
 };

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -1,0 +1,83 @@
+#ifndef AU_STREAM_SOCKET_IMPL_H_
+#define AU_STREAM_SOCKET_IMPL_H_
+
+#include <memory>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <map>
+#include "au_stream_socket.h"
+#include "common_socket_impl.h"
+#include "au_stream_addr_map.h"
+
+namespace au_stream_socket {
+
+const int IPPROTO_AU = 151;
+
+class messages_broker {
+public:
+  static messages_broker& get() {
+    static messages_broker p;
+    return p;
+  }
+
+  void run();
+
+  void start_listen(std::shared_ptr<listener_impl> sock);
+  void stop_listen(sockaddr_in addr);
+
+  void add_connection(std::shared_ptr<connection_impl> sock);
+  void remove_connection(sockaddr_in local, sockaddr_in remote);
+
+private:
+  messages_broker() : thread_(messages_broker::run, this) {
+    thread_.detach();
+  }
+
+  std::thread thread_;
+  std::mutex mutex_;
+  addr_map<std::shared_ptr<listener_impl>> listeners_;
+  addr_map<addr_map<std::shared_ptr<connection_impl>>> connections_;
+};
+
+class listener_impl {
+public:
+  listener_impl(sockaddr_in addr);
+  ~listener_impl();
+  sockaddr_in get_addr() const;
+  void shutdown();
+
+  void process_packet(const char *data, size_t len);
+
+  std::shared_ptr<connection_impl> accept_one_client();
+
+private:
+  sockaddr_in addr_;
+  bool shutdown_;
+
+  std::mutex mutex_;
+  std::condition_variable accept_wakeup_;
+  std::queue<std::shared_ptr<connection_impl>> clients_;
+};
+
+class connection_impl {
+public:
+  connection_impl(sockaddr_in local, sockaddr_in remote);
+  sockaddr_in get_local() const;
+  sockaddr_in get_remote() const;
+
+  void process_packet(const char *data, size_t len);
+
+  void start_connection();
+  size_t send(const char *buf, size_t size);
+  size_t recv(char *buf, size_t size);
+  void shutdown();
+
+private:
+  sockaddr_in local_, remote_;
+};
+
+}  // namespace au_stream_socket
+
+#endif  // AU_STREAM_SOCKET_IMPL_H_

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -31,7 +31,7 @@ public:
   void remove_connection(sockaddr_in local, sockaddr_in remote);
 
 private:
-  messages_broker() : thread_(messages_broker::run, this) {
+  messages_broker() : thread_(&messages_broker::run, this) {
     thread_.detach();
   }
 

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -39,6 +39,8 @@ private:
   }
 
   void process_packet(const au_packet &packet);
+  void add_connection_locked(std::shared_ptr<connection_impl> sock);
+  void remove_connection_locked(sockaddr_in local, sockaddr_in remote);
 
   std::thread thread_;
   std::mutex mutex_;

--- a/task1-2/inc/au_stream_socket_impl.h
+++ b/task1-2/inc/au_stream_socket_impl.h
@@ -40,7 +40,7 @@ private:
     thread_.detach();
   }
 
-  void process_packet(const au_packet &packet);
+  void process_packet(au_packet packet);
   void add_connection_lock_held(std::shared_ptr<connection_impl> sock);
   void remove_connection_lock_held(sockaddr_in local, sockaddr_in remote);
 
@@ -82,7 +82,7 @@ public:
   sockaddr_in get_local() const;
   sockaddr_in get_remote() const;
 
-  void process_packet(const au_packet &packet);
+  void process_packet(au_packet packet);
 
   void start_connection();
   void send(const char *buf, size_t size);

--- a/task1-2/inc/au_stream_socket_protocol.h
+++ b/task1-2/inc/au_stream_socket_protocol.h
@@ -8,12 +8,17 @@
 namespace au_stream_socket {
 
 enum class Flags : uint8_t {
+  NONE = 0,
   SYN = 1,
   ACK = 2
 };
 
 inline Flags operator|(Flags a, Flags b) {
   return static_cast<Flags>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+inline Flags operator&(Flags a, Flags b) {
+  return static_cast<Flags>(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
 }
 
 struct au_packet {

--- a/task1-2/inc/au_stream_socket_protocol.h
+++ b/task1-2/inc/au_stream_socket_protocol.h
@@ -10,7 +10,8 @@ namespace au_stream_socket {
 enum class Flags : uint8_t {
   NONE = 0,
   SYN = 1,
-  ACK = 2
+  ACK = 2,
+  FIN = 4
 };
 
 inline Flags operator|(Flags a, Flags b) {

--- a/task1-2/inc/au_stream_socket_protocol.h
+++ b/task1-2/inc/au_stream_socket_protocol.h
@@ -1,0 +1,37 @@
+#ifndef AU_STREAM_SOCKET_PROTOCOL_H_
+#define AU_STREAM_SOCKET_PROTOCOL_H_
+
+#include <vector>
+#include <stdexcept>
+#include "common_socket_impl.h"
+
+namespace au_stream_socket {
+
+enum class Flags : uint8_t {
+  SYN = 1,
+  ACK = 2
+};
+
+inline Flags operator|(Flags a, Flags b) {
+  return static_cast<Flags>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+struct au_packet {
+  sockaddr_in source, dest;
+  uint32_t sn, ack_sn;
+  Flags flags;
+  std::vector<char> data;
+};
+
+class invalid_packet : public std::runtime_error {
+public:
+  invalid_packet(const char *msg) : std::runtime_error(msg) {}
+};
+
+int serialize(const au_packet &packet, char *buf, size_t len);
+
+au_packet deserialize(sockaddr_in source, sockaddr_in dest, char *buf, size_t len);
+
+}  // namespace au_stream_socket
+
+#endif  // AU_STREAM_SOCKET_PROTOCOL_H_

--- a/task1-2/inc/common_socket_impl.h
+++ b/task1-2/inc/common_socket_impl.h
@@ -1,0 +1,58 @@
+#ifndef COMMON_SOCKET_IMPL_H_
+
+#include <assert.h>
+#ifdef _WIN32
+#include <w32api.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
+#include <string>
+#include <sstream>
+
+#ifdef _WIN32
+// INVALID_SOCKET is already defined
+// SOCKET_ERROR is already defined
+#else
+static const int INVALID_SOCKET = -1;
+static const int SOCKET_ERROR = -1;
+#define closesocket close
+#endif
+
+#ifdef _WIN32
+class WSAStartupper {
+public:
+  WSAStartupper() {
+    WSADATA data;
+    assert(WSAStartup(MAKEWORD(2, 2), &data) == 0);
+  }
+  // We do not call WSACleanup() because of troubles with order of global ctors/dtors.
+private:
+  WSAStartupper(WSAStartupper &&) = delete;
+  WSAStartupper(const WSAStartupper&) = delete;
+  WSAStartupper& operator=(WSAStartupper) = delete;
+};
+#define SOCKET_STARTUP() static WSAStartupper wsa_startupper_;
+#else
+#define SOCKET_STARTUP()
+#endif
+
+std::string get_socket_error(int code);
+
+std::string get_socket_error();
+
+template<typename T>
+void ensure_or_throw_impl(bool condition, const char *errname, const char *funname, const char *file, int line, const char *cond) {
+  if (!condition) {
+    std::stringstream msg;
+    msg << errname << " in " << funname << "() at " << file << ":" << line << ": condition " << cond << " failed: " << get_socket_error();
+    throw T(msg.str());
+  }
+}
+#define ensure_or_throw(cond, error) ensure_or_throw_impl<error>(cond, #error, __FUNCTION__, __FILE__, __LINE__, #cond)
+
+#endif

--- a/task1-2/inc/common_socket_impl.h
+++ b/task1-2/inc/common_socket_impl.h
@@ -1,4 +1,5 @@
 #ifndef COMMON_SOCKET_IMPL_H_
+#define COMMON_SOCKET_IMPL_H_
 
 #include <assert.h>
 #ifdef _WIN32

--- a/task1-2/inc/common_socket_impl.h
+++ b/task1-2/inc/common_socket_impl.h
@@ -14,6 +14,7 @@
 #endif
 #include <string>
 #include <sstream>
+#include <iostream>
 
 #ifdef _WIN32
 // INVALID_SOCKET is already defined
@@ -67,5 +68,9 @@ public:
 private:
   addrinfo *addrs;
 };
+
+inline std::ostream& operator<<(std::ostream &os, const sockaddr_in &addr) {
+  return os << inet_ntoa(addr.sin_addr) << ":" << ntohs(addr.sin_port);
+}
 
 #endif

--- a/task1-2/inc/common_socket_impl.h
+++ b/task1-2/inc/common_socket_impl.h
@@ -11,6 +11,7 @@
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <arpa/inet.h>
 #endif
 #include <string>
 #include <sstream>
@@ -20,6 +21,7 @@
 // INVALID_SOCKET is already defined
 // SOCKET_ERROR is already defined
 #else
+typedef int SOCKET;
 static const int INVALID_SOCKET = -1;
 static const int SOCKET_ERROR = -1;
 #define closesocket close

--- a/task1-2/inc/common_socket_impl.h
+++ b/task1-2/inc/common_socket_impl.h
@@ -56,4 +56,16 @@ void ensure_or_throw_impl(bool condition, const char *errname, const char *funna
 }
 #define ensure_or_throw(cond, error) ensure_or_throw_impl<error>(cond, #error, __FUNCTION__, __FILE__, __LINE__, #cond)
 
+class NameResolver {
+public:
+  NameResolver(const char *host, int ai_family, int ai_socktype, int ai_protocol, int port = 0);
+  ~NameResolver();
+
+  const sockaddr* ai_addr() { return addrs->ai_addr; }
+  int ai_addrlen() { return addrs->ai_addrlen; }
+
+private:
+  addrinfo *addrs;
+};
+
 #endif

--- a/task1-2/inc/tcp_socket.h
+++ b/task1-2/inc/tcp_socket.h
@@ -4,12 +4,7 @@
 #include <stdint.h>
 #include <string>
 #include "stream_socket.h"
-
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-typedef int SOCKET;
-#endif
+#include "common_socket_impl.h"
 
 typedef uint16_t tcp_port;
 

--- a/task1-2/inc/test.h
+++ b/task1-2/inc/test.h
@@ -1,6 +1,0 @@
-#ifndef TEST_H_
-#define TEST_H_
-
-void test_protocol();
-
-#endif  // TEST_H_

--- a/task1-2/inc/utils/cyclic_queue.h
+++ b/task1-2/inc/utils/cyclic_queue.h
@@ -1,0 +1,89 @@
+#ifndef CYCLIC_QUEUE_H
+#define CYCLIC_QUEUE_H
+
+#include <cstdint>
+#include <type_traits>
+#include <assert.h>
+
+template<typename T, typename I, std::size_t max_size>
+class cyclic_queue {
+public:
+  explicit cyclic_queue(I init_id = 0) : data_start_(0), data_end_(0), data_size_(0), id_start_(init_id), id_end_(init_id) {
+    static_assert(std::is_unsigned<I>::value, "IDs inside cyclic_queue's should be unsigned to support integer overflows");
+  }
+
+  bool empty() const {
+    return data_size_ == 0;
+  }
+
+  bool full() const {
+    return data_size_ == max_size;
+  }
+
+  void reset_id(I new_id) {
+    assert(empty());
+    id_start_ = id_end_ = new_id;
+  }
+
+  bool contains(I id) const {
+    if (data_size_ == 0) {
+      return false;
+    }
+    if (id_start_ < id_end_) {
+      return id_start_ <= id && id < id_end_;
+    } else {
+      return id_start_ <= id || id < id_end_;
+    }
+  }
+
+  T& operator[](I id) {
+    assert(contains(id));
+    id -= id_start_;
+    std::size_t pos = id + data_start_;
+    if (pos >= max_size) {
+      pos -= max_size;
+    }
+    assert(pos < max_size);
+    return data_[pos];
+  }
+
+  T& front() {
+    return data_[data_start_];
+  }
+
+  void pop_front() {
+    assert(data_size_ >= 1);
+    data_size_ -= 1;
+    data_start_ += 1;
+    id_start_ += 1;
+    if (data_start_ >= max_size) {
+      data_start_ -= max_size;
+    }
+  }
+
+  void push_back(const T &value) {
+    data_[data_end_] = value;
+    assert(data_size_ + 1 <= max_size);
+    data_size_ += 1;
+    data_end_ += 1;
+    id_end_ += 1;
+    if (data_end_ >= max_size) {
+      data_end_ -= max_size;
+    }
+  }
+
+  I begin_id() const {
+    return id_start_;
+  }
+
+  I end_id() const {
+    return id_end_;
+  }
+
+private:
+  T data_[max_size];
+  std::size_t data_start_, data_end_, data_size_;
+  I id_start_, id_end_;
+};
+
+#endif

--- a/task1-2/inc/utils/event.h
+++ b/task1-2/inc/utils/event.h
@@ -1,6 +1,9 @@
 #ifndef SEMAPHORE_H
 #define SEMAPHORE_H
 
+#include <mutex>
+#include <condition_variable>
+
 class event {
 public:
   event() : happened_(false) {

--- a/task1-2/inc/utils/event.h
+++ b/task1-2/inc/utils/event.h
@@ -1,0 +1,28 @@
+#ifndef SEMAPHORE_H
+#define SEMAPHORE_H
+
+class event {
+public:
+  event() : happened_(false) {
+  }
+
+  void await() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this]() {
+      return happened_;
+    });
+  }
+
+  void notify() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    happened_ = true;
+    cond_.notify_all();
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  bool happened_;
+};
+
+#endif  // SEMAPHORE_H

--- a/task1-2/inc/utils/locking_char_queue.h
+++ b/task1-2/inc/utils/locking_char_queue.h
@@ -1,0 +1,76 @@
+#ifndef LOCKING_CHAR_QUEUE_H
+#define LOCKING_CHAR_QUEUE_H
+
+#include <mutex>
+#include <condition_variable>
+#include <exception>
+#include "utils/cyclic_queue.h"
+
+struct locking_char_queue_shut_down : std::runtime_error {
+  locking_char_queue_shut_down() : std::runtime_error("locking_char_queue was shut down") {}
+};
+
+template<std::size_t max_size>
+class locking_char_queue {
+public:
+  locking_char_queue() : shutdown_(false) {}
+
+  void shutdown() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    assert(!shutdown_);
+    shutdown_ = true;
+    send_cond_.notify_all();
+    recv_cond_.notify_all();
+  }
+
+  void send(const char *buf, size_t size) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (size > 0) {
+      send_cond_.wait(lock, [this]() {
+        return shutdown_ || !queue.full();
+      });
+      if (shutdown_) {
+        throw locking_char_queue_shut_down();
+      }
+      while (size > 0 && !queue.full()) {
+        queue.push_back(*buf);
+        buf++;
+        size--;
+      }
+      recv_cond_.notify_one();
+      if (!size && !queue.full()) {
+        send_cond_.notify_one();
+      }
+    }
+  }
+
+  void recv(char *buf, size_t size) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (size > 0) {
+      recv_cond_.wait(lock, [this]() {
+        return shutdown_ || !queue.empty();
+      });
+      if (shutdown_) {
+        throw locking_char_queue_shut_down();
+      }
+      while (size > 0 && !queue.empty()) {
+        *buf = queue.front();
+        queue.pop_front();
+        buf++;
+        size--;
+      }
+      send_cond_.notify_one();
+      if (!size && !queue.empty()) {
+        recv_cond_.notify_one();
+      }
+    }
+  }
+  
+private:
+  std::mutex mutex_;
+  std::condition_variable send_cond_, recv_cond_;
+  bool shutdown_;
+  cyclic_queue<char, std::size_t, max_size> queue;
+};
+
+#endif  // LOCKING_CHAR_QUEUE_H

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -53,8 +53,16 @@ public:
     }
   }
 
-  size_t try_send(T *buf, size_t size) {
+  size_t try_send(const T *buf, size_t size) {
     std::unique_lock<std::mutex> lock(mutex_);
+    return try_send_lock_held(buf, size);
+  }
+
+  size_t try_send_or_block(const T *buf, size_t size) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    send_cond_.wait(lock, [this]() {
+      return shutdown_ || !queue_.full();
+    });
     return try_send_lock_held(buf, size);
   }
 

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -17,7 +17,10 @@ public:
 
   void shutdown() {
     std::lock_guard<std::mutex> lock(mutex_);
-    assert(!shutdown_);
+    shutdown_lock_held();
+  }
+
+  void shutdown_lock_held() {
     shutdown_ = true;
     send_cond_.notify_all();
     recv_cond_.notify_all();

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -13,7 +13,7 @@ struct locking_queue_shut_down : std::runtime_error {
 template<typename T, std::size_t max_size>
 class locking_queue {
 public:
-  locking_queue() : shutdown_(false) {}
+  locking_queue(std::mutex &mutex) : mutex_(mutex), shutdown_(false) {}
 
   void shutdown() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -95,7 +95,7 @@ private:
     return recved;
   }
 
-  std::mutex mutex_;
+  std::mutex &mutex_;
   std::condition_variable send_cond_, recv_cond_;
   bool shutdown_;
   cyclic_queue<T, std::size_t, max_size> queue_;

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -1,19 +1,19 @@
-#ifndef LOCKING_CHAR_QUEUE_H
-#define LOCKING_CHAR_QUEUE_H
+#ifndef LOCKING_QUEUE_H
+#define LOCKING_QUEUE_H
 
 #include <mutex>
 #include <condition_variable>
 #include <exception>
 #include "utils/cyclic_queue.h"
 
-struct locking_char_queue_shut_down : std::runtime_error {
-  locking_char_queue_shut_down() : std::runtime_error("locking_char_queue was shut down") {}
+struct locking_queue_shut_down : std::runtime_error {
+  locking_queue_shut_down() : std::runtime_error("locking_queue was shut down") {}
 };
 
-template<std::size_t max_size>
-class locking_char_queue {
+template<typename T, std::size_t max_size>
+class locking_queue {
 public:
-  locking_char_queue() : shutdown_(false) {}
+  locking_queue() : shutdown_(false) {}
 
   void shutdown() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -23,14 +23,14 @@ public:
     recv_cond_.notify_all();
   }
 
-  void send(const char *buf, size_t size) {
+  void send(const T *buf, size_t size) {
     std::unique_lock<std::mutex> lock(mutex_);
     while (size > 0) {
       send_cond_.wait(lock, [this]() {
         return shutdown_ || !queue.full();
       });
       if (shutdown_) {
-        throw locking_char_queue_shut_down();
+        throw locking_queue_shut_down();
       }
       while (size > 0 && !queue.full()) {
         queue.push_back(*buf);
@@ -44,7 +44,7 @@ public:
     }
   }
 
-  void recv(char *buf, size_t size) {
+  void recv(T *buf, size_t size) {
     std::unique_lock<std::mutex> lock(mutex_);
     while (size > 0) {
       recv_cond_.wait(lock, [this]() {
@@ -59,15 +59,15 @@ public:
     }
   }
 
-  size_t try_recv(char *buf, size_t size) {
+  size_t try_recv(T *buf, size_t size) {
     std::unique_lock<std::mutex> lock(mutex_);
     return try_recv_lock_held(buf, size);
   }
   
 private:
-  size_t try_recv_lock_held(char *buf, size_t size) {
+  size_t try_recv_lock_held(T *buf, size_t size) {
     if (shutdown_) {
-      throw locking_char_queue_shut_down();
+      throw locking_queue_shut_down();
     }
     size_t recved = 0;
     while (size > 0 && !queue.empty()) {
@@ -84,7 +84,7 @@ private:
   std::mutex mutex_;
   std::condition_variable send_cond_, recv_cond_;
   bool shutdown_;
-  cyclic_queue<char, std::size_t, max_size> queue;
+  cyclic_queue<T, std::size_t, max_size> queue;
 };
 
-#endif  // LOCKING_CHAR_QUEUE_H
+#endif  // LOCKING_QUEUE_H

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -10,7 +10,7 @@ struct locking_queue_shut_down : std::runtime_error {
   locking_queue_shut_down() : std::runtime_error("locking_queue was shut down") {}
 };
 
-template<typename T, std::size_t max_size>
+template<typename T, typename I, std::size_t max_size>
 class locking_queue {
 public:
   locking_queue(std::mutex &mutex) : mutex_(mutex), shutdown_(false) {}
@@ -62,6 +62,10 @@ public:
     std::unique_lock<std::mutex> lock(mutex_);
     return try_recv_lock_held(buf, size);
   }
+
+  cyclic_queue<T, I, max_size>& queue_lock_held() {
+    return queue_;
+  }
   
 private:
   size_t try_send_lock_held(const T *buf, size_t size) {
@@ -98,7 +102,7 @@ private:
   std::mutex &mutex_;
   std::condition_variable send_cond_, recv_cond_;
   bool shutdown_;
-  cyclic_queue<T, std::size_t, max_size> queue_;
+  cyclic_queue<T, I, max_size> queue_;
 };
 
 #endif  // LOCKING_QUEUE_H

--- a/task1-2/inc/utils/locking_queue.h
+++ b/task1-2/inc/utils/locking_queue.h
@@ -75,7 +75,6 @@ public:
     return queue_;
   }
   
-private:
   size_t try_send_lock_held(const T *buf, size_t size) {
     if (shutdown_) {
       throw locking_queue_shut_down();
@@ -107,6 +106,7 @@ private:
     return recved;
   }
 
+private:
   std::mutex &mutex_;
   std::condition_variable send_cond_, recv_cond_;
   bool shutdown_;

--- a/task1-2/inc/utils/retrier.h
+++ b/task1-2/inc/utils/retrier.h
@@ -1,0 +1,42 @@
+#ifndef RETRIER_H
+#define RETRIER_H
+
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+#include <queue>
+
+class retrier {
+public:
+  typedef std::chrono::milliseconds duration;
+  typedef std::function<bool(void)> function;
+
+  retrier();
+  ~retrier();
+
+  void retry_after(duration delay, function function);
+
+private:
+  typedef std::chrono::time_point<std::chrono::steady_clock> time_point;
+  struct queue_item {
+    time_point retry_at;
+    duration delay;
+    function function;
+
+    bool operator>(const queue_item &other) const {
+      return retry_at > other.retry_at;
+    }
+  };
+
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  std::priority_queue<queue_item, std::vector<queue_item>, std::greater<queue_item>> queue_;
+  bool terminating_;
+
+  void run();
+};
+
+#endif  // RETRIER_H

--- a/task1-2/inc/utils/retrier.h
+++ b/task1-2/inc/utils/retrier.h
@@ -23,7 +23,7 @@ private:
   struct queue_item {
     time_point retry_at;
     duration delay;
-    function function;
+    function func;
 
     bool operator>(const queue_item &other) const {
       return retry_at > other.retry_at;

--- a/task1-2/src/au_stream_socket.cpp
+++ b/task1-2/src/au_stream_socket.cpp
@@ -10,12 +10,16 @@
 
 using au_stream_socket::messages_broker;
 
+namespace {
+
 sockaddr_in resolve(hostname host, int port) {
   NameResolver resolver(host, AF_INET, SOCK_STREAM, 0, port);
   assert(resolver.ai_addrlen() == sizeof(sockaddr_in));
   const sockaddr_in *addr = reinterpret_cast<const sockaddr_in*>(resolver.ai_addr());
   return *addr;
 }
+
+}  // namespace
 
 void au_stream_connection_socket::send(const void *orig_buf, size_t size) {
   if (!impl_) {

--- a/task1-2/src/au_stream_socket.cpp
+++ b/task1-2/src/au_stream_socket.cpp
@@ -11,7 +11,7 @@
 using au_stream_socket::messages_broker;
 
 sockaddr_in resolve(hostname host, int port) {
-  NameResolver resolver(host, AF_INET, SOCK_STREAM, au_stream_socket::IPPROTO_AU, port);
+  NameResolver resolver(host, AF_INET, SOCK_STREAM, 0, port);
   assert(resolver.ai_addrlen() == sizeof(sockaddr_in));
   const sockaddr_in *addr = reinterpret_cast<const sockaddr_in*>(resolver.ai_addr());
   return *addr;

--- a/task1-2/src/au_stream_socket.cpp
+++ b/task1-2/src/au_stream_socket.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <mutex>
 #include <map>
+#include <string.h>
 
 #include "au_stream_socket.h"
 #include "common_socket_impl.h"

--- a/task1-2/src/au_stream_socket.cpp
+++ b/task1-2/src/au_stream_socket.cpp
@@ -21,34 +21,18 @@ sockaddr_in resolve(hostname host, int port) {
 
 }  // namespace
 
-void au_stream_connection_socket::send(const void *orig_buf, size_t size) {
+void au_stream_connection_socket::send(const void *buf, size_t size) {
   if (!impl_) {
     throw socket_uninitialized("Socket is uninitialized");
   }
-  const char *cbuf = static_cast<const char*>(orig_buf);
-  while (size > 0) {
-    size_t wrote = impl_->send(cbuf, size);
-    if (!wrote) {
-      throw std::logic_error("send() returned zero instead of blocking");
-    }
-    cbuf += wrote;
-    size -= wrote;
-  }
+  impl_->send(static_cast<const char*>(buf), size);
 }
 
-void au_stream_connection_socket::recv(void *orig_buf, size_t size) {
+void au_stream_connection_socket::recv(void *buf, size_t size) {
   if (!impl_) {
     throw socket_uninitialized("Socket is uninitialized");
   }
-  char *cbuf = static_cast<char*>(orig_buf);
-  while (size > 0) {
-    size_t read = impl_->recv(cbuf, size);
-    if (!read) {
-      throw std::logic_error("recv() returned zero instead of blocking");
-    }
-    cbuf += read;
-    size -= read;
-  }
+  impl_->recv(static_cast<char*>(buf), size);
 }
 
 au_stream_connection_socket::operator bool() {

--- a/task1-2/src/au_stream_socket.cpp
+++ b/task1-2/src/au_stream_socket.cpp
@@ -1,0 +1,130 @@
+#include <assert.h>
+#include <thread>
+#include <mutex>
+#include <map>
+
+#include "au_stream_socket.h"
+#include "common_socket_impl.h"
+
+class au_stream_socket_processor {
+public:
+  static au_stream_socket_processor& get() {
+    static au_stream_socket_processor p;
+    return p;
+  }
+
+  void run();
+
+  std::shared_ptr<au_stream_socket_data> socket(au_stream_port port);
+  void closesocket(std::shared_ptr<au_stream_socket_data> sock);
+
+private:
+  au_stream_socket_processor() : thread_(au_stream_socket_processor::run, this) {
+  }
+  ~au_stream_socket_processor() {
+    assert(false);
+  }
+
+  std::thread thread_;
+  std::mutex mutex_;
+  std::map<au_stream_port, std::shared_ptr<au_stream_socket_data>> sockets_;
+};
+
+class au_stream_socket_data {
+public:
+  au_stream_socket_data(au_stream_port port) : port_(port) {}
+
+  au_stream_port get_port() const {
+    return port_;
+  }
+
+private:
+  au_stream_port port_;
+};
+
+void au_stream_socket_processor::run() {
+  // TODO: actually do something
+}
+
+std::shared_ptr<au_stream_socket_data> au_stream_socket_processor::socket(au_stream_port port) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  assert(port != 0);
+
+  auto it = sockets_.lower_bound(port);
+  if (it != sockets_.end() && it->first == port) {
+    std::stringstream msg;
+    msg << "Someone is already bound to port " << port;
+    throw socket_error(msg.str().c_str());
+  }
+
+  auto impl = std::make_shared<au_stream_socket_data>(port);
+  sockets_.emplace(port, impl);
+  return impl;
+}
+
+void au_stream_socket_processor::closesocket(std::shared_ptr<au_stream_socket_data> sock) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = sockets_.find(sock->get_port());
+  if (it == sockets_.end() || it->second != sock) {
+    return;
+  }
+  // TODO: gracefully close the socket
+  sockets_.erase(it);
+}
+
+au_stream_connection_socket::~au_stream_connection_socket() {
+  auto impl = impl_.lock();
+  if (impl) {
+    au_stream_socket_processor::get().closesocket(impl);
+  }
+}
+
+bool au_stream_connection_socket::bind(au_stream_port port) {
+  auto impl = impl_.lock();
+  if (impl) {
+    return false;
+  }
+  impl_ = au_stream_socket_processor::get().socket(port);
+  return true;
+}
+
+void au_stream_connection_socket::send(const void *buf, size_t size) {
+  auto impl = impl_.lock();
+  // TODO: actually send
+  (void)buf;
+  (void)size;
+}
+void au_stream_connection_socket::recv(void *buf, size_t size) {
+  auto impl = impl_.lock();
+  // TODO: actually recv
+  (void)buf;
+  (void)size;
+}
+
+au_stream_client_socket::au_stream_client_socket(hostname host, au_stream_port client_port, au_stream_port server_port)
+  : host_(host)
+  , client_port_(client_port)
+  , server_port_(server_port) {}
+
+void au_stream_client_socket::connect() {
+  sock_.bind(client_port_);
+  // TODO: actually connect
+}
+
+au_stream_server_socket::au_stream_server_socket(hostname host, au_stream_port port)
+  : impl_(au_stream_socket_processor::get().socket(port)) {
+  // TODO: start listening
+  (void)host;
+}
+
+au_stream_server_socket::~au_stream_server_socket() {
+  auto impl = impl_.lock();
+  if (impl) {
+    au_stream_socket_processor::get().closesocket(impl);
+  }
+}
+
+stream_socket* au_stream_server_socket::accept_one_client() {
+  // TODO: actually accept
+  assert(false);
+}

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -5,12 +5,6 @@
 #include <stdexcept>
 #include <vector>
 
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-typedef int SOCKET;
-#endif
-
 namespace au_stream_socket {
 
 void messages_broker::start_listen(std::shared_ptr<listener_impl> sock) {

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -24,10 +24,10 @@ void messages_broker::stop_listen(sockaddr_in addr) {
 
 void messages_broker::add_connection(std::shared_ptr<connection_impl> sock) {
   std::lock_guard<std::mutex> lock(mutex_);
-  add_connection_locked(sock);
+  add_connection_lock_held(sock);
 }
 
-void messages_broker::add_connection_locked(std::shared_ptr<connection_impl> sock) {
+void messages_broker::add_connection_lock_held(std::shared_ptr<connection_impl> sock) {
   auto &conns = connections_[sock->get_remote()];
   if (conns.contains(sock->get_local())) {
     throw socket_error("There is already a similar connection");
@@ -37,11 +37,11 @@ void messages_broker::add_connection_locked(std::shared_ptr<connection_impl> soc
 
 //void messages_broker::remove_connection(sockaddr_in local, sockaddr_in remote) {
 //  std::lock_guard<std::mutex> lock(mutex_);
-//  remove_connection_locked(local, remote);
+//  remove_connection_lock_held(local, remote);
 //  // TODO
 //}
 
-//void messages_broker::remove_connection_locked(sockaddr_in local, sockaddr_in remote) {
+//void messages_broker::remove_connection_lock_held(sockaddr_in local, sockaddr_in remote) {
 //  // TODO
 //}
 

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -58,6 +58,7 @@ void messages_broker::run() {
   bind_addr.sin_family = AF_INET;
   ensure_or_throw(bind(s, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) == 0, socket_error);
 
+  initialized.notify();
   static thread_local char buffer[8192];
   for (;;) {
     sockaddr_in from;

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -1,5 +1,12 @@
 #include "au_stream_socket_impl.h"
 #include <iostream>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+typedef int SOCKET;
+#endif
 
 namespace au_stream_socket {
 
@@ -44,7 +51,7 @@ void messages_broker::run() {
   static thread_local char buffer[8192];
   for (;;) {
     sockaddr_in from;
-    int fromlen = sizeof from;
+    socklen_t fromlen = sizeof from;
     std::cerr << "recvfrom\n";
     int size = recvfrom(s, buffer, sizeof buffer, 0, reinterpret_cast<sockaddr*>(&from), &fromlen);
     ensure_or_throw(size > 0, socket_io_error);

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -35,15 +35,18 @@ void messages_broker::add_connection_lock_held(std::shared_ptr<connection_impl> 
   conns.insert(sock->get_local(), sock);
 }
 
-//void messages_broker::remove_connection(sockaddr_in local, sockaddr_in remote) {
-//  std::lock_guard<std::mutex> lock(mutex_);
-//  remove_connection_lock_held(local, remote);
-//  // TODO
-//}
-
-//void messages_broker::remove_connection_lock_held(sockaddr_in local, sockaddr_in remote) {
-//  // TODO
-//}
+void messages_broker::remove_connection_from_process_packet(sockaddr_in local, sockaddr_in remote) {
+  // Lock is already held.
+  auto conns = connections_.find(remote);
+  if (conns == connections_.end()) {
+    throw socket_error("No such connection");
+  }
+  auto conns2 = conns->second.find(local);
+  if (conns2 == conns->second.end()) {
+    throw socket_error("No such connection");
+  }
+  conns->second.erase(conns2);
+}
 
 void messages_broker::run() {
   SOCKET_STARTUP();

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -1,0 +1,132 @@
+#include "au_stream_socket_impl.h"
+#include <iostream>
+
+namespace au_stream_socket {
+
+void messages_broker::start_listen(std::shared_ptr<listener_impl> sock) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (listeners_.contains(sock->get_addr())) {
+    throw socket_error("Someone already listens on this local port");
+  }
+  listeners_.insert(sock->get_addr(), sock);
+}
+
+void messages_broker::stop_listen(sockaddr_in addr) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = listeners_.find(addr);
+  assert(it != listeners_.end());
+  listeners_.erase(it);
+}
+
+void messages_broker::add_connection(std::shared_ptr<connection_impl> sock) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto &conns = connections_[sock->get_remote()];
+  if (conns.contains(sock->get_local())) {
+    throw socket_error("There is already a similar connection");
+  }
+  conns.insert(sock->get_local(), sock);
+}
+
+//void messages_broker::remove_socket(std::shared_ptr<connection_impl>) {
+//  // TODO
+//}
+
+void messages_broker::run() {
+  SOCKET_STARTUP();
+  SOCKET s = socket(AF_INET, SOCK_RAW, IPPROTO_AU);
+  ensure_or_throw(s != INVALID_SOCKET, socket_error);
+
+  sockaddr_in bind_addr;
+  memset(&bind_addr, 0, sizeof bind_addr);
+  bind_addr.sin_family = AF_INET;
+  ensure_or_throw(bind(s, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) == 0, socket_error);
+
+  static thread_local char buffer[8192];
+  for (;;) {
+    sockaddr_in from;
+    int fromlen = sizeof from;
+    std::cerr << "recvfrom\n";
+    int size = recvfrom(s, buffer, sizeof buffer, 0, reinterpret_cast<sockaddr*>(&from), &fromlen);
+    ensure_or_throw(size > 0, socket_io_error);
+
+    std::cerr << "size=" << size << "\n";
+  }
+}
+
+listener_impl::listener_impl(sockaddr_in addr) : addr_(addr), shutdown_(false) {
+}
+
+listener_impl::~listener_impl() {
+  assert(shutdown_);
+}
+
+sockaddr_in listener_impl::get_addr() const {
+  return addr_;
+}
+
+void listener_impl::shutdown() {
+  messages_broker::get().stop_listen(addr_);  
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  shutdown_ = true;
+  accept_wakeup_.notify_all();
+}
+
+std::shared_ptr<connection_impl> listener_impl::accept_one_client() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  accept_wakeup_.wait(lock, [this]() {
+    return shutdown_ || !clients_.empty();
+  });
+  if (!clients_.empty()) {
+    auto result = clients_.front();
+    clients_.pop();
+    return result;
+  }
+  assert(shutdown_);
+  throw socket_error("Listening socket was shut down");
+}
+
+connection_impl::connection_impl(sockaddr_in local, sockaddr_in remote)
+  : local_(local), remote_(remote) {
+}
+
+sockaddr_in connection_impl::get_local() const {
+  return local_;
+}
+
+sockaddr_in connection_impl::get_remote() const {
+  return remote_;
+}
+
+void connection_impl::start_connection() {
+  std::cerr << "start_connection\n";
+  SOCKET_STARTUP();
+  SOCKET s = socket(AF_INET, SOCK_RAW, IPPROTO_AU);
+  ensure_or_throw(s != INVALID_SOCKET, socket_error);
+
+  ensure_or_throw(bind(s, reinterpret_cast<sockaddr*>(&local_), sizeof(local_)) == 0, socket_error);
+
+  char data[] = { 10, 20, 30, 40, 41 };
+  ensure_or_throw(sendto(s, data, sizeof data, 0, reinterpret_cast<sockaddr*>(&remote_), sizeof(remote_)) == (sizeof data), socket_io_error);
+  // TODO
+}
+
+size_t connection_impl::send(const char *buf, size_t size) {
+  // TODO
+  (void)buf;
+  (void)size;
+  for(;;);
+}
+
+size_t connection_impl::recv(char *buf, size_t size) {
+  // TODO
+  (void)buf;
+  (void)size;
+  for(;;);
+}
+
+void connection_impl::shutdown() {
+  // TODO
+}
+
+}  // namespace au_stream_socket

--- a/task1-2/src/au_stream_socket_impl.cpp
+++ b/task1-2/src/au_stream_socket_impl.cpp
@@ -24,6 +24,10 @@ void messages_broker::stop_listen(sockaddr_in addr) {
 
 void messages_broker::add_connection(std::shared_ptr<connection_impl> sock) {
   std::lock_guard<std::mutex> lock(mutex_);
+  add_connection_locked(sock);
+}
+
+void messages_broker::add_connection_locked(std::shared_ptr<connection_impl> sock) {
   auto &conns = connections_[sock->get_remote()];
   if (conns.contains(sock->get_local())) {
     throw socket_error("There is already a similar connection");
@@ -31,7 +35,13 @@ void messages_broker::add_connection(std::shared_ptr<connection_impl> sock) {
   conns.insert(sock->get_local(), sock);
 }
 
-//void messages_broker::remove_socket(std::shared_ptr<connection_impl>) {
+//void messages_broker::remove_connection(sockaddr_in local, sockaddr_in remote) {
+//  std::lock_guard<std::mutex> lock(mutex_);
+//  remove_connection_locked(local, remote);
+//  // TODO
+//}
+
+//void messages_broker::remove_connection_locked(sockaddr_in local, sockaddr_in remote) {
 //  // TODO
 //}
 

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -262,8 +262,8 @@ void connection_impl::process_packet(au_packet packet) {
       #endif
     } catch (const locking_queue_shut_down&) {
     }
-    if (flushed || send_window_changed) {
-      send_some_data(flushed ? Flags::ACK : Flags::NONE);
+    if (!packet.data.empty() || send_window_changed) {
+      send_some_data(Flags::ACK);
     }
   } else {
     std::cerr << "Received some packet from " << packet.source << " to " << packet.dest

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -104,7 +104,7 @@ connection_impl::connection_impl(sockaddr_in local, sockaddr_in remote)
   ensure_or_throw(bind(sock_, reinterpret_cast<sockaddr*>(&local_), sizeof(local_)) == 0, socket_error);
 }
 
-void connection_impl::send_packet(Flags flags, uint32_t sn, const std::vector<char> data) {
+void connection_impl::send_packet(Flags flags, uint32_t sn, std::vector<char> data) {
   au_packet ans;
   ans.source = local_;
   ans.dest = remote_;

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -1,0 +1,181 @@
+#include "au_stream_socket_protocol.h"
+#include "au_stream_socket_impl.h"
+#include "common_socket_impl.h"
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <string.h>
+
+namespace au_stream_socket {
+
+static const size_t MAX_SEGMENT_SIZE = 1000;
+
+// Bytes  Description
+// 0-1    source port (network order)
+// 2-3    destination port (network order)
+// 4-7    sequence number (network order)
+// 8-11   ack sequence number (network order)
+// 12     flags
+// 13-15  reserved
+// 16-19  checksum (all bytes of packet XORed together should yield zero)
+
+int serialize(const au_packet &packet, char *buf, size_t len) {
+  assert(20 + packet.data.size() <= len);
+
+  memset(buf, 0, 20);
+  *reinterpret_cast<uint16_t*>(buf + 0) = packet.source.sin_port;
+  *reinterpret_cast<uint16_t*>(buf + 2) = packet.dest.sin_port;
+  *reinterpret_cast<uint32_t*>(buf + 4) = htonl(packet.sn);
+  *reinterpret_cast<uint32_t*>(buf + 8) = htonl(packet.ack_sn);
+  *reinterpret_cast<Flags*>(buf + 12) = packet.flags;
+  copy(packet.data.begin(), packet.data.end(), buf + 20);
+
+  for (size_t checksum_pos = 0; checksum_pos < 4; checksum_pos++) {
+    uint8_t expected = 0;
+    for (size_t i = checksum_pos; i < len; i += 4) {
+      expected ^= buf[i];
+    }
+    buf[16 + checksum_pos] = expected;
+  }
+  return 20 + packet.data.size();
+}
+
+au_packet deserialize(sockaddr_in source, sockaddr_in dest, char *buf, size_t len) {
+  if (len < 20) {
+    throw invalid_packet("Packet is too short");
+  }
+  for (size_t checksum_pos = 0; checksum_pos < 4; checksum_pos++) {
+    uint8_t expected = 0;
+    for (size_t i = checksum_pos; i < len; i += 4) {
+      expected ^= buf[i];
+    }
+    if (expected) {
+      throw invalid_packet("Invalid checksum");
+    }
+  }
+
+  au_packet result;
+  result.source = source;
+  result.source.sin_port =       *reinterpret_cast<uint16_t*>(buf + 0);
+  result.dest = dest;
+  result.dest.sin_port   =       *reinterpret_cast<uint16_t*>(buf + 2);
+  result.sn              = ntohl(*reinterpret_cast<uint32_t*>(buf + 4));
+  result.ack_sn          = ntohl(*reinterpret_cast<uint32_t*>(buf + 8));
+  result.flags           =       *reinterpret_cast<Flags*>(buf + 12);
+  result.data.assign(buf + 20, buf + len);
+  return result;
+}
+
+void messages_broker::process_packet(const au_packet &packet) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  {
+    auto it1 = connections_.find(packet.source);
+    if (it1 != connections_.end()) {
+      auto it2 = it1->second.find(packet.dest);
+      if (it2 != it1->second.end()) {
+        it2->second->process_packet(packet);
+        return;
+      }
+    }
+  }
+  auto it = listeners_.find(packet.dest);
+  assert(listeners_.begin() != listeners_.end());
+  if (it != listeners_.end() && packet.flags == Flags::SYN) {
+    auto &listener = it->second;
+    auto conn = std::make_shared<connection_impl>(packet.dest, packet.source);
+    conn->process_packet(packet);
+    listener->add_client(conn);
+    connections_[conn->get_remote()][conn->get_local()] = conn;
+    return;
+  }
+  std::cerr << "Received unknown packet from " << packet.source << " to " << packet.dest
+            << "; data_len=" << packet.data.size()
+            << "; flags=" << static_cast<int>(packet.flags)
+            << "\n";
+}
+
+connection_impl::connection_impl(sockaddr_in local, sockaddr_in remote)
+  : sock_(), local_(local), remote_(remote), state_(CLOSED), recv_sn(0) {
+  SOCKET_STARTUP();
+  
+  static std::default_random_engine engine;
+  static std::mutex engine_mutex;
+  {
+    std::lock_guard<std::mutex> lock(engine_mutex);
+    send_sn = engine();
+  }
+
+  sock_ = socket(AF_INET, SOCK_RAW, IPPROTO_AU);
+  ensure_or_throw(sock_ != INVALID_SOCKET, socket_error);
+  ensure_or_throw(bind(sock_, reinterpret_cast<sockaddr*>(&local_), sizeof(local_)) == 0, socket_error);
+}
+
+void connection_impl::send_packet(Flags flags, const std::vector<bool> data) {
+  au_packet ans;
+  ans.source = local_;
+  ans.dest = remote_;
+  ans.flags = flags;
+  ans.sn = send_sn;
+  ans.ack_sn = recv_sn;
+
+  static thread_local char buf[20 + MAX_SEGMENT_SIZE];
+  int len = serialize(ans, buf, sizeof buf);
+  ensure_or_throw(sendto(sock_, buf, len, 0, reinterpret_cast<sockaddr*>(&remote_), sizeof(remote_)) == len, socket_io_error);
+}
+
+void connection_impl::start_connection() {
+  assert(state_ == CLOSED);
+
+  send_packet(Flags::SYN, {});
+  std::cerr << "Switch --> SYN_SENT\n";
+  state_ = SYN_SENT;
+}
+
+void connection_impl::process_packet(const au_packet &packet) {
+  if (state_ == CLOSED && packet.flags == Flags::SYN) {
+    recv_sn = packet.sn + 1;
+    send_packet(Flags::SYN | Flags::ACK, {});
+    state_ = SYN_RECV;
+    std::cerr << "Switch CLOSED --> SYN_SENT\n";
+  } else if (state_ == SYN_SENT && packet.flags == (Flags::SYN | Flags::ACK)) {
+    if (send_sn + 1 != packet.ack_sn) {
+      return;  // Fail
+    }
+    recv_sn = packet.sn + 1;
+    send_packet(Flags::ACK, {});
+    state_ = ESTABLISHED;
+    std::cerr << "Switch SYN_SENT --> ESTABLISHED\n";
+  } else if (state_ == SYN_RECV && packet.flags == Flags::ACK) {
+    if (send_sn + 1 != packet.ack_sn || recv_sn != packet.sn + 1) {
+      return;  // Fail
+    }
+    state_ = ESTABLISHED;
+    std::cerr << "Switch SYN_RECV --> ESTABLISHED\n";
+  } else {
+    std::cerr << "Received some packet from " << packet.source << " to " << packet.dest
+              << "; data_len=" << packet.data.size()
+              << "; flags=" << static_cast<int>(packet.flags)
+              << "\n";
+    return;
+  }
+}
+
+size_t connection_impl::send(const char *buf, size_t size) {
+  // TODO
+  (void)buf;
+  (void)size;
+  for(;;);
+}
+
+size_t connection_impl::recv(char *buf, size_t size) {
+  // TODO
+  (void)buf;
+  (void)size;
+  for(;;);
+}
+
+void connection_impl::shutdown() {
+  // TODO
+}
+
+}  // namespace au_stream_socket

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -86,7 +86,7 @@ void messages_broker::process_packet(const au_packet &packet) {
     auto conn = std::make_shared<connection_impl>(packet.dest, packet.source);
     conn->process_packet(packet);
     listener->add_client(conn);
-    add_connection_locked(conn);
+    add_connection_lock_held(conn);
     return;
   }
   std::cerr << "Received unknown packet from " << packet.source << " to " << packet.dest

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -22,6 +22,7 @@ static const size_t AU_PACKET_HEADER_SIZE = 20;
 
 int serialize(const au_packet &packet, char *buf, size_t len) {
   assert(AU_PACKET_HEADER_SIZE + packet.data.size() <= len);
+  len = AU_PACKET_HEADER_SIZE + packet.data.size();
 
   memset(buf, 0, AU_PACKET_HEADER_SIZE);
   *reinterpret_cast<uint16_t*>(buf + 0) = packet.source.sin_port;
@@ -38,7 +39,7 @@ int serialize(const au_packet &packet, char *buf, size_t len) {
     }
     buf[16 + checksum_pos] = expected;
   }
-  return AU_PACKET_HEADER_SIZE + packet.data.size();
+  return len;
 }
 
 au_packet deserialize(sockaddr_in source, sockaddr_in dest, char *buf, size_t len) {

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -85,7 +85,6 @@ void messages_broker::process_packet(au_packet packet) {
     }
   }
   auto it = listeners_.find(packet.dest);
-  assert(listeners_.begin() != listeners_.end());
   if (it != listeners_.end() && packet.flags == Flags::SYN) {
     auto &listener = it->second;
     auto conn = std::make_shared<connection_impl>(packet.dest, packet.source);
@@ -94,10 +93,12 @@ void messages_broker::process_packet(au_packet packet) {
     add_connection_lock_held(conn);
     return;
   }
+  #ifdef AU_DEBUG
   std::cerr << "Received unknown packet from " << packet.source << " to " << packet.dest
             << "; data_len=" << packet.data.size()
             << "; flags=" << static_cast<int>(packet.flags)
             << "\n";
+  #endif
 }
 
 connection_impl::connection_impl(sockaddr_in local, sockaddr_in remote)

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -85,7 +85,7 @@ void messages_broker::process_packet(const au_packet &packet) {
     auto conn = std::make_shared<connection_impl>(packet.dest, packet.source);
     conn->process_packet(packet);
     listener->add_client(conn);
-    connections_[conn->get_remote()][conn->get_local()] = conn;
+    add_connection_locked(conn);
     return;
   }
   std::cerr << "Received unknown packet from " << packet.source << " to " << packet.dest

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -252,7 +252,7 @@ void connection_impl::send_some_data(Flags flags) {
     std::vector<char> data(buf, buf + size);
 
     #ifdef AU_DEBUG
-    std::cout << "Sending packet with flags=" << static_cast<int>(flags) << ", data starts from " << send_window_queue.begin_id() << " and goes for " << data.size << "\n";
+    std::cout << "Sending packet with flags=" << static_cast<int>(flags) << ", data starts from " << send_window_queue.begin_id() << " and goes for " << data.size() << "\n";
     #endif
     send_packet(flags, begin_id, data);
 
@@ -263,7 +263,7 @@ void connection_impl::send_some_data(Flags flags) {
         return true;
       }
       #ifdef AU_DEBUG
-      std::cout << "Sending packet with flags=" << static_cast<int>(flags) << ", data starts from " << send_window_queue.begin_id() << " and goes for " << data.size() << "\n";
+      std::cout << "Sending packet with flags=" << static_cast<int>(flags) << ", data starts from " << begin_id << " and goes for " << data.size() << "\n";
       #endif
       send_packet(flags, begin_id, data);
       return false;

--- a/task1-2/src/au_stream_socket_protocol.cpp
+++ b/task1-2/src/au_stream_socket_protocol.cpp
@@ -96,7 +96,7 @@ void messages_broker::process_packet(au_packet packet) {
 }
 
 connection_impl::connection_impl(sockaddr_in local, sockaddr_in remote)
-  : sock_(), local_(local), remote_(remote), state_(CLOSED) {
+  : sock_(), local_(local), remote_(remote), state_(CLOSED), ack_sn(0), send_queue(mutex_), recv_queue(mutex_) {
   SOCKET_STARTUP();
   send_window.reset_id(10);  // Arbitrary const greater than zero (so we can call send_window.begin_id() - 1)
   sock_ = socket(AF_INET, SOCK_RAW, IPPROTO_AU);

--- a/task1-2/src/common_socket_impl.cpp
+++ b/task1-2/src/common_socket_impl.cpp
@@ -1,0 +1,31 @@
+#include "common_socket_impl.h"
+#include <sstream>
+#include <string>
+
+std::string get_socket_error(int code) {
+  #ifdef _WIN32
+  LPVOID msg_buf;
+  assert(FormatMessage(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER |
+      FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL,
+      code,
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (LPTSTR)&msg_buf,
+      0, NULL) != 0);
+  std::string result((char*)msg_buf);
+  LocalFree(msg_buf);
+  return result;
+  #else
+  return strerror(code);
+  #endif
+}
+
+std::string get_socket_error() {
+  #ifdef _WIN32
+  return get_socket_error(WSAGetLastError());
+  #else
+  return get_socket_error(errno);
+  #endif
+}

--- a/task1-2/src/common_socket_impl.cpp
+++ b/task1-2/src/common_socket_impl.cpp
@@ -34,6 +34,7 @@ std::string get_socket_error() {
 
 
 NameResolver::NameResolver(const char *host, int ai_family, int ai_socktype, int ai_protocol, int port) {
+  SOCKET_STARTUP();
   addrinfo hints;
   memset(&hints, 0, sizeof hints);
   hints.ai_family = ai_family;

--- a/task1-2/src/common_socket_impl.cpp
+++ b/task1-2/src/common_socket_impl.cpp
@@ -2,6 +2,7 @@
 #include "stream_socket.h"
 #include <sstream>
 #include <string>
+#include <string.h>
 
 std::string get_socket_error(int code) {
   #ifdef _WIN32

--- a/task1-2/src/retrier.cpp
+++ b/task1-2/src/retrier.cpp
@@ -19,8 +19,8 @@ void retrier::retry_after(duration delay, function function) {
 }
 
 void retrier::run() {
+  std::unique_lock<std::mutex> lock(mutex_);
   while (true) {
-    std::unique_lock<std::mutex> lock(mutex_);
     if (queue_.empty()) {
       cond_.wait(lock);
     } else {
@@ -34,7 +34,7 @@ void retrier::run() {
         break;
       }
       duration delay = queue_.top().delay;
-      function function = std::move(queue_.top().function);
+      function function = std::move(queue_.top().func);
       queue_.pop();
       if (!function()) {
         queue_.push({std::chrono::steady_clock::now() + delay, delay, std::move(function)});

--- a/task1-2/src/retrier.cpp
+++ b/task1-2/src/retrier.cpp
@@ -1,0 +1,44 @@
+#include "utils/retrier.h"
+
+retrier::retrier() : thread_(&retrier::run, this), terminating_(false) {
+}
+
+retrier::~retrier() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    terminating_ = true;
+    cond_.notify_one();
+  }
+  thread_.join();
+}
+
+void retrier::retry_after(duration delay, function function) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  queue_.push({std::chrono::steady_clock::now() + delay, delay, std::move(function)});
+  cond_.notify_one();
+}
+
+void retrier::run() {
+  while (true) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (queue_.empty()) {
+      cond_.wait(lock);
+    } else {
+      cond_.wait_until(lock, queue_.top().retry_at);
+    }
+    if (terminating_) {
+      break;
+    }
+    while (!queue_.empty()) {
+      if (std::chrono::steady_clock::now() < queue_.top().retry_at) {
+        break;
+      }
+      duration delay = queue_.top().delay;
+      function function = std::move(queue_.top().function);
+      queue_.pop();
+      if (!function()) {
+        queue_.push({std::chrono::steady_clock::now() + delay, delay, std::move(function)});
+      }
+    }
+  }
+}

--- a/task1-2/src/test.cpp
+++ b/task1-2/src/test.cpp
@@ -7,7 +7,7 @@
 #include <pthread.h>
 
 #define TEST_TCP_STREAM_SOCKET
-//#define TEST_AU_STREAM_SOCKET
+#define TEST_AU_STREAM_SOCKET
 
 #include "stream_socket.h"
 #ifdef TEST_TCP_STREAM_SOCKET

--- a/task1-2/src/test.cpp
+++ b/task1-2/src/test.cpp
@@ -69,6 +69,7 @@ static void test_stream_sockets_datapipe()
             buf[buf_ix] = i;
         server_client->send(buf, sizeof(buf));
     }
+    pthread_join(th, NULL);
 }
 
 static void* test_stream_sockets_partial_data_sent_thread_func(void *)
@@ -102,6 +103,7 @@ static void test_stream_sockets_partial_data_sent()
         thrown = true;
     }
     assert(thrown);
+    pthread_join(th, NULL);
 }
 
 #ifdef TEST_TCP_STREAM_SOCKET

--- a/task1-2/src/test_cyclic_queue.cpp
+++ b/task1-2/src/test_cyclic_queue.cpp
@@ -1,0 +1,131 @@
+#include "utils/cyclic_queue.h"
+#include <gtest/gtest.h>
+
+const int64_t BILLION = 1000000000;
+
+TEST(CyclicQueue, Init) {
+  cyclic_queue<int64_t, uint8_t, 3> q;
+  EXPECT_TRUE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(0, q.begin_id());
+  EXPECT_EQ(0, q.end_id());
+  EXPECT_FALSE(q.contains(0));
+  EXPECT_FALSE(q.contains(1));
+}
+
+TEST(CyclicQueue, ResetId) {
+  cyclic_queue<int64_t, uint8_t, 3> q;
+
+  q.reset_id(200);
+  EXPECT_EQ(200, q.begin_id());
+  EXPECT_EQ(200, q.end_id());
+  EXPECT_FALSE(q.contains(0));
+  EXPECT_FALSE(q.contains(200));
+  EXPECT_FALSE(q.contains(201));
+}
+
+TEST(CyclicQueue, SeveralPushes) {
+  cyclic_queue<int64_t, uint8_t, 3> q;
+  q.reset_id(254);
+
+  q.push_back(10 * BILLION);
+  EXPECT_FALSE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(254, q.begin_id());
+  EXPECT_EQ(255, q.end_id());
+  EXPECT_FALSE(q.contains(253));
+  EXPECT_FALSE(q.contains(255));
+  ASSERT_TRUE(q.contains(254));
+  EXPECT_EQ(10 * BILLION, q[254]);
+
+  q.push_back(20 * BILLION);
+  EXPECT_FALSE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(254, q.begin_id());
+  EXPECT_EQ(0, q.end_id());
+  EXPECT_FALSE(q.contains(253));
+  EXPECT_FALSE(q.contains(0));
+  ASSERT_TRUE(q.contains(254));
+  ASSERT_TRUE(q.contains(255));
+  EXPECT_EQ(10 * BILLION, q[254]);
+  EXPECT_EQ(20 * BILLION, q[255]);
+
+  q.push_back(30 * BILLION);
+  EXPECT_FALSE(q.empty());
+  EXPECT_TRUE(q.full());
+  EXPECT_EQ(254, q.begin_id());
+  EXPECT_EQ(1, q.end_id());
+  EXPECT_FALSE(q.contains(253));
+  EXPECT_FALSE(q.contains(1));
+  ASSERT_TRUE(q.contains(254));
+  ASSERT_TRUE(q.contains(255));
+  ASSERT_TRUE(q.contains(0));
+  EXPECT_EQ(10 * BILLION, q[254]);
+  EXPECT_EQ(20 * BILLION, q[255]);
+  EXPECT_EQ(30 * BILLION, q[0]);
+}
+
+TEST(CyclicQueue, SeveralPops) {
+  cyclic_queue<int64_t, uint8_t, 3> q;
+  q.reset_id(254);
+  q.push_back(10 * BILLION);
+  q.push_back(20 * BILLION);
+  q.push_back(30 * BILLION);
+
+  q.pop_front();
+  EXPECT_FALSE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(255, q.begin_id());
+  EXPECT_EQ(1, q.end_id());
+  EXPECT_FALSE(q.contains(254));
+  EXPECT_FALSE(q.contains(1));
+  ASSERT_TRUE(q.contains(255));
+  ASSERT_TRUE(q.contains(0));
+  EXPECT_EQ(20 * BILLION, q[255]);
+  EXPECT_EQ(30 * BILLION, q[0]);
+
+  q.pop_front();
+  EXPECT_FALSE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(0, q.begin_id());
+  EXPECT_EQ(1, q.end_id());
+  EXPECT_FALSE(q.contains(255));
+  EXPECT_FALSE(q.contains(1));
+  ASSERT_TRUE(q.contains(0));
+  EXPECT_EQ(30 * BILLION, q[0]);
+
+  q.pop_front();
+  EXPECT_TRUE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(1, q.begin_id());
+  EXPECT_EQ(1, q.end_id());
+  EXPECT_FALSE(q.contains(0));
+  EXPECT_FALSE(q.contains(1));
+}
+
+TEST(CyclicQueue, Cycling) {
+  cyclic_queue<int64_t, uint8_t, 3> q;
+  q.reset_id(250);
+  q.push_back(10 * BILLION);
+  q.push_back(20 * BILLION);
+  q.push_back(30 * BILLION);
+  q.pop_front();
+  q.push_back(40 * BILLION);
+  q.pop_front();
+  q.push_back(50 * BILLION);
+  q.pop_front();
+  q.pop_front();
+  q.push_back(60 * BILLION);
+  q.push_back(70 * BILLION);
+  q.pop_front();
+  q.push_back(80 * BILLION);
+  q.pop_front();
+  q.pop_front();
+
+  EXPECT_FALSE(q.empty());
+  EXPECT_FALSE(q.full());
+  EXPECT_EQ(1, q.begin_id());
+  EXPECT_EQ(2, q.end_id());
+  ASSERT_TRUE(q.contains(1));
+  EXPECT_EQ(80 * BILLION, q[1]);
+}

--- a/task1-2/src/test_locking_char_queue.cpp
+++ b/task1-2/src/test_locking_char_queue.cpp
@@ -1,0 +1,144 @@
+#include "utils/locking_char_queue.h"
+#include <gtest/gtest.h>
+#include <random>
+#include <thread>
+#include <atomic>
+#include <assert.h>
+
+class barrier {
+public:
+  explicit barrier(int counter) : counter_(counter) {
+  }
+  ~barrier() {
+    assert(counter_ == 0);
+  }
+
+  void await() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    assert(counter_ > 0);
+    counter_--;
+    if (!counter_) {
+      cond_.notify_all();
+    }
+    cond_.wait(lock, [this]() {
+      return counter_ == 0;
+    });
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  int counter_;
+};
+
+TEST(LockingCharQueue, SingleThreadSmoke) {
+  locking_char_queue<6> q;
+  char buffer[] = { 1, 2, 3, 4, 5 };
+  q.send(buffer, 3);
+  q.send(buffer + 2, 3);
+
+  char recved[5] = {};
+  q.recv(recved, 5);
+  EXPECT_EQ(1, recved[0]);
+  EXPECT_EQ(2, recved[1]);
+  EXPECT_EQ(3, recved[2]);
+  EXPECT_EQ(3, recved[3]);
+  EXPECT_EQ(4, recved[4]);
+
+  q.recv(recved, 1);
+  EXPECT_EQ(5, recved[0]);
+
+  q.shutdown();
+}
+
+TEST(LockingCharQueue, ProducerConsumer) {
+  const int TRANSMISSION_SIZE = 100000;
+  const int MIN_BLOCK_SIZE = 1;
+  const int MAX_BLOCK_SIZE = 20;
+
+  locking_char_queue<16> q;
+  std::thread producer([&q]() {
+    std::default_random_engine gen;
+    std::uniform_int_distribution<int> distrib(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    for (int i = 0; i < TRANSMISSION_SIZE;) {
+      char block[MAX_BLOCK_SIZE];
+      int block_size = std::min(TRANSMISSION_SIZE - i, distrib(gen));
+      for (int in_block = 0; in_block < block_size; in_block++) {
+        block[in_block] = static_cast<unsigned char>(i);
+        i++;
+      }
+      q.send(block, block_size);
+    }
+  });
+
+  std::vector<char> received;
+  bool consumer_stopped;
+  std::thread consumer([&q, &received, &consumer_stopped]() {
+    std::default_random_engine gen;
+    std::uniform_int_distribution<int> distrib(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    for (int i = 0; i < TRANSMISSION_SIZE;) {
+      char block[MAX_BLOCK_SIZE];
+      int block_size = std::min(TRANSMISSION_SIZE - i, distrib(gen));
+      q.recv(block, block_size);
+      received.insert(received.end(), block, block + block_size);
+      i += block_size;
+    }
+  });
+
+  producer.join();
+  consumer.join();
+  q.shutdown();
+
+  ASSERT_EQ(TRANSMISSION_SIZE, received.size());
+  for (int i = 0; i < TRANSMISSION_SIZE; i++) {
+    ASSERT_EQ(static_cast<unsigned char>(i), static_cast<unsigned char>(received[i]));
+  }
+}
+
+TEST(LockingCharQueue, ShutdownAbortsSend) {
+  locking_char_queue<10> q;
+  barrier barrier(2);
+  bool aborted;
+  std::thread producer([&q, &barrier, &aborted]() {
+    char block[10] = {};
+    q.send(block, 5);
+    barrier.await();
+    try {
+      q.send(block, 6);
+    } catch (const locking_char_queue_shut_down&) {
+      aborted = true;
+    }
+  });
+  barrier.await();
+
+  EXPECT_FALSE(aborted);
+  q.shutdown();
+  producer.join();
+  EXPECT_TRUE(aborted);
+}
+
+TEST(LockingCharQueue, ShutdownAbortsRecv) {
+  locking_char_queue<10> q;
+  barrier barrier(2);
+  bool aborted;
+  std::thread consumer([&q, &barrier, &aborted]() {
+    char block[10] = {};
+    q.recv(block, 5);
+    barrier.await();
+    try {
+      q.recv(block, 6);
+    } catch (const locking_char_queue_shut_down&) {
+      aborted = true;
+    }
+  });
+  {
+    char block[10] = {};
+    q.send(block, sizeof block);
+  }
+  barrier.await();
+
+  EXPECT_FALSE(aborted);
+  q.shutdown();
+  consumer.join();
+  EXPECT_TRUE(aborted);
+}

--- a/task1-2/src/test_locking_char_queue.cpp
+++ b/task1-2/src/test_locking_char_queue.cpp
@@ -51,6 +51,33 @@ TEST(LockingCharQueue, SingleThreadSmoke) {
   q.shutdown();
 }
 
+TEST(LockingCharQueue, TryRecv) {
+  locking_char_queue<6> q;
+  char buffer[] = { 1, 2, 3, 4, 5 };
+  q.send(buffer, 3);
+  q.send(buffer + 2, 3);
+
+  char recved[5] = {};
+  ASSERT_EQ(4, q.try_recv(recved, 4));
+  EXPECT_EQ(1, recved[0]);
+  EXPECT_EQ(2, recved[1]);
+  EXPECT_EQ(3, recved[2]);
+  EXPECT_EQ(3, recved[3]);
+
+  ASSERT_EQ(2, q.try_recv(recved, 4));
+  EXPECT_EQ(4, recved[0]);
+  EXPECT_EQ(5, recved[1]);
+
+  ASSERT_EQ(0, q.try_recv(recved, 4));
+
+  q.send(buffer, 1);
+
+  ASSERT_EQ(1, q.try_recv(recved, 4));
+  EXPECT_EQ(1, recved[0]);
+
+  q.shutdown();
+}
+
 TEST(LockingCharQueue, ProducerConsumer) {
   const int TRANSMISSION_SIZE = 100000;
   const int MIN_BLOCK_SIZE = 1;

--- a/task1-2/src/test_locking_queue.cpp
+++ b/task1-2/src/test_locking_queue.cpp
@@ -128,7 +128,7 @@ TEST(LockingCharQueue, ShutdownAbortsSend) {
   std::mutex m;
   locking_queue<char, std::size_t, 10> q(m);
   event ev;
-  bool aborted;
+  bool aborted = false;
   std::thread producer([&q, &ev, &aborted]() {
     char block[10] = {};
     q.send(block, 5);
@@ -151,7 +151,7 @@ TEST(LockingCharQueue, ShutdownAbortsRecv) {
   std::mutex m;
   locking_queue<char, std::size_t, 10> q(m);
   event ev;
-  bool aborted;
+  bool aborted = false;
   std::thread consumer([&q, &ev, &aborted]() {
     char block[10] = {};
     q.recv(block, 5);

--- a/task1-2/src/test_locking_queue.cpp
+++ b/task1-2/src/test_locking_queue.cpp
@@ -51,6 +51,29 @@ TEST(LockingCharQueue, SingleThreadSmoke) {
   q.shutdown();
 }
 
+TEST(LockingCharQueue, TrySend) {
+  locking_queue<char, 4> q;
+  char buffer[] = { 1, 2, 3, 4, 5 };
+  ASSERT_EQ(3, q.try_send(buffer, 3));
+  ASSERT_EQ(1, q.try_send(buffer + 2, 3));
+
+  char recved[4] = {};
+  q.recv(recved, 4);
+  EXPECT_EQ(1, recved[0]);
+  EXPECT_EQ(2, recved[1]);
+  EXPECT_EQ(3, recved[2]);
+  EXPECT_EQ(3, recved[3]);
+
+  ASSERT_EQ(4, q.try_send(buffer, 5));
+  q.recv(recved, 4);
+  EXPECT_EQ(1, recved[0]);
+  EXPECT_EQ(2, recved[1]);
+  EXPECT_EQ(3, recved[2]);
+  EXPECT_EQ(4, recved[3]);
+
+  q.shutdown();
+}
+
 TEST(LockingCharQueue, TryRecv) {
   locking_queue<char, 6> q;
   char buffer[] = { 1, 2, 3, 4, 5 };

--- a/task1-2/src/test_locking_queue.cpp
+++ b/task1-2/src/test_locking_queue.cpp
@@ -1,4 +1,4 @@
-#include "utils/locking_char_queue.h"
+#include "utils/locking_queue.h"
 #include <gtest/gtest.h>
 #include <random>
 #include <thread>
@@ -32,7 +32,7 @@ private:
 };
 
 TEST(LockingCharQueue, SingleThreadSmoke) {
-  locking_char_queue<6> q;
+  locking_queue<char, 6> q;
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -52,7 +52,7 @@ TEST(LockingCharQueue, SingleThreadSmoke) {
 }
 
 TEST(LockingCharQueue, TryRecv) {
-  locking_char_queue<6> q;
+  locking_queue<char, 6> q;
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -83,7 +83,7 @@ TEST(LockingCharQueue, ProducerConsumer) {
   const int MIN_BLOCK_SIZE = 1;
   const int MAX_BLOCK_SIZE = 20;
 
-  locking_char_queue<16> q;
+  locking_queue<char, 16> q;
   std::thread producer([&q]() {
     std::default_random_engine gen;
     std::uniform_int_distribution<int> distrib(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
@@ -123,7 +123,7 @@ TEST(LockingCharQueue, ProducerConsumer) {
 }
 
 TEST(LockingCharQueue, ShutdownAbortsSend) {
-  locking_char_queue<10> q;
+  locking_queue<char, 10> q;
   barrier barrier(2);
   bool aborted;
   std::thread producer([&q, &barrier, &aborted]() {
@@ -132,7 +132,7 @@ TEST(LockingCharQueue, ShutdownAbortsSend) {
     barrier.await();
     try {
       q.send(block, 6);
-    } catch (const locking_char_queue_shut_down&) {
+    } catch (const locking_queue_shut_down&) {
       aborted = true;
     }
   });
@@ -145,7 +145,7 @@ TEST(LockingCharQueue, ShutdownAbortsSend) {
 }
 
 TEST(LockingCharQueue, ShutdownAbortsRecv) {
-  locking_char_queue<10> q;
+  locking_queue<char, 10> q;
   barrier barrier(2);
   bool aborted;
   std::thread consumer([&q, &barrier, &aborted]() {
@@ -154,7 +154,7 @@ TEST(LockingCharQueue, ShutdownAbortsRecv) {
     barrier.await();
     try {
       q.recv(block, 6);
-    } catch (const locking_char_queue_shut_down&) {
+    } catch (const locking_queue_shut_down&) {
       aborted = true;
     }
   });

--- a/task1-2/src/test_locking_queue.cpp
+++ b/task1-2/src/test_locking_queue.cpp
@@ -32,7 +32,8 @@ private:
 };
 
 TEST(LockingCharQueue, SingleThreadSmoke) {
-  locking_queue<char, 6> q;
+  std::mutex m;
+  locking_queue<char, 6> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -52,7 +53,8 @@ TEST(LockingCharQueue, SingleThreadSmoke) {
 }
 
 TEST(LockingCharQueue, TrySend) {
-  locking_queue<char, 4> q;
+  std::mutex m;
+  locking_queue<char, 4> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   ASSERT_EQ(3, q.try_send(buffer, 3));
   ASSERT_EQ(1, q.try_send(buffer + 2, 3));
@@ -75,7 +77,8 @@ TEST(LockingCharQueue, TrySend) {
 }
 
 TEST(LockingCharQueue, TryRecv) {
-  locking_queue<char, 6> q;
+  std::mutex m;
+  locking_queue<char, 6> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -106,7 +109,8 @@ TEST(LockingCharQueue, ProducerConsumer) {
   const int MIN_BLOCK_SIZE = 1;
   const int MAX_BLOCK_SIZE = 20;
 
-  locking_queue<char, 16> q;
+  std::mutex m;
+  locking_queue<char, 16> q(m);
   std::thread producer([&q]() {
     std::default_random_engine gen;
     std::uniform_int_distribution<int> distrib(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
@@ -146,7 +150,8 @@ TEST(LockingCharQueue, ProducerConsumer) {
 }
 
 TEST(LockingCharQueue, ShutdownAbortsSend) {
-  locking_queue<char, 10> q;
+  std::mutex m;
+  locking_queue<char, 10> q(m);
   barrier barrier(2);
   bool aborted;
   std::thread producer([&q, &barrier, &aborted]() {
@@ -168,7 +173,8 @@ TEST(LockingCharQueue, ShutdownAbortsSend) {
 }
 
 TEST(LockingCharQueue, ShutdownAbortsRecv) {
-  locking_queue<char, 10> q;
+  std::mutex m;
+  locking_queue<char, 10> q(m);
   barrier barrier(2);
   bool aborted;
   std::thread consumer([&q, &barrier, &aborted]() {

--- a/task1-2/src/test_locking_queue.cpp
+++ b/task1-2/src/test_locking_queue.cpp
@@ -33,7 +33,7 @@ private:
 
 TEST(LockingCharQueue, SingleThreadSmoke) {
   std::mutex m;
-  locking_queue<char, 6> q(m);
+  locking_queue<char, std::size_t, 6> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -54,7 +54,7 @@ TEST(LockingCharQueue, SingleThreadSmoke) {
 
 TEST(LockingCharQueue, TrySend) {
   std::mutex m;
-  locking_queue<char, 4> q(m);
+  locking_queue<char, std::size_t, 4> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   ASSERT_EQ(3, q.try_send(buffer, 3));
   ASSERT_EQ(1, q.try_send(buffer + 2, 3));
@@ -78,7 +78,7 @@ TEST(LockingCharQueue, TrySend) {
 
 TEST(LockingCharQueue, TryRecv) {
   std::mutex m;
-  locking_queue<char, 6> q(m);
+  locking_queue<char, std::size_t, 6> q(m);
   char buffer[] = { 1, 2, 3, 4, 5 };
   q.send(buffer, 3);
   q.send(buffer + 2, 3);
@@ -110,7 +110,7 @@ TEST(LockingCharQueue, ProducerConsumer) {
   const int MAX_BLOCK_SIZE = 20;
 
   std::mutex m;
-  locking_queue<char, 16> q(m);
+  locking_queue<char, std::size_t, 16> q(m);
   std::thread producer([&q]() {
     std::default_random_engine gen;
     std::uniform_int_distribution<int> distrib(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
@@ -151,7 +151,7 @@ TEST(LockingCharQueue, ProducerConsumer) {
 
 TEST(LockingCharQueue, ShutdownAbortsSend) {
   std::mutex m;
-  locking_queue<char, 10> q(m);
+  locking_queue<char, std::size_t, 10> q(m);
   barrier barrier(2);
   bool aborted;
   std::thread producer([&q, &barrier, &aborted]() {
@@ -174,7 +174,7 @@ TEST(LockingCharQueue, ShutdownAbortsSend) {
 
 TEST(LockingCharQueue, ShutdownAbortsRecv) {
   std::mutex m;
-  locking_queue<char, 10> q(m);
+  locking_queue<char, std::size_t, 10> q(m);
   barrier barrier(2);
   bool aborted;
   std::thread consumer([&q, &barrier, &aborted]() {

--- a/task1-2/src/test_protocol.cpp
+++ b/task1-2/src/test_protocol.cpp
@@ -1,9 +1,9 @@
-#include "test.h"
 #include "stream_socket.h"
 #include "protocol.h"
 #include <assert.h>
 #include <sstream>
 #include <set>
+#include <gtest/gtest.h>
 
 class stringstream_socket : public stream_socket {
 public:
@@ -93,13 +93,17 @@ template<typename T> void test_message() {
   }
 }
 
-void test_protocol() {
-  ids.clear();
-  test_message<RegistrationMessage>();
-  test_message<LoginMessage>();
-  test_message<RegistrationResponse>();
-  test_message<BalanceInquiryRequest>();
-  test_message<BalanceInquiryResponse>();
-  test_message<TransferRequest>();
-  test_message<OperationSucceeded>();
+// FIXME: tests depend on each and are not thread-safe other because `id` is a global variable
+
+#define ADD_TEST(msg) \
+TEST(ProtocolTest, msg) { \
+  test_message<msg>(); \
 }
+
+ADD_TEST(RegistrationMessage)
+ADD_TEST(LoginMessage)
+ADD_TEST(RegistrationResponse)
+ADD_TEST(BalanceInquiryRequest)
+ADD_TEST(BalanceInquiryResponse)
+ADD_TEST(TransferRequest)
+ADD_TEST(OperationSucceeded)

--- a/task1-2/src/test_retrier.cpp
+++ b/task1-2/src/test_retrier.cpp
@@ -1,0 +1,59 @@
+#include "utils/event.h"
+#include "utils/retrier.h"
+#include <chrono>
+#include <mutex>
+#include <gtest/gtest.h>
+#include <assert.h>
+
+typedef std::chrono::time_point<std::chrono::steady_clock> time_point;
+
+TEST(Retrier, BasicMultipleTest) {
+  std::mutex m;
+  std::vector<std::pair<time_point, int>> stamps;
+  
+  retrier r;
+  event ev1;
+  int counter1 = 0;
+  r.retry_after(std::chrono::milliseconds(8), [&m, &stamps, &ev1, &counter1]() {
+    std::lock_guard<std::mutex> lock(m);
+    stamps.push_back(std::make_pair(std::chrono::steady_clock::now(), 10 + counter1));
+    counter1++;
+    if (counter1 == 3) {
+      ev1.notify();
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  event ev2;
+  int counter2 = 0;
+  r.retry_after(std::chrono::milliseconds(10), [&m, &stamps, &ev2, &counter2]() {
+    std::lock_guard<std::mutex> lock(m);
+    stamps.push_back(std::make_pair(std::chrono::steady_clock::now(), 20 + counter2));
+    counter2++;
+    if (counter2 == 2) {
+      ev2.notify();
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  ev1.await();
+  ev2.await();
+  ASSERT_EQ(5, stamps.size());
+  EXPECT_EQ(10, stamps[0].second); // 8ms
+  EXPECT_EQ(20, stamps[1].second); // 10ms
+  EXPECT_EQ(11, stamps[2].second); // 16ms
+  EXPECT_EQ(21, stamps[3].second); // 20ms
+  EXPECT_EQ(12, stamps[4].second); // 24ms
+}
+
+TEST(Retrier, Termination) {
+  retrier r;
+  r.retry_after(std::chrono::milliseconds(50), []() {
+    assert(false);
+    return false;
+  });
+}


### PR DESCRIPTION
Что-то какая-то адовая жесть у меня получилась.

Что умеет:
* Перепосылать пакет, если за 100мс не получил подтверждение.
* Перепосылать какие-то из кусков установки соединения/завершения, если за 100 мс не получили подтверждение.
* Работать под виндой (нужно запускать под админом, в консоли есть утилитка `elevate.exe`) и под линуксом (нужно запускать под рутом).

Что не умеет:
* Оптимизации
* Посылать больше одного пакета (сойдёт за оптимизацию, кстати, или надо что-нибудь посерьёзнее?)
* Убивает соединение по таймауту или количеству попыток.
* Убивать соединение при получении Ctrl+C в программе (так-то ядро TCP-сессии подчищает-закрывает, но нет).
* Выбирать локальный порт для клиента умнее, чем рандомом с надеждой в глазах.

Как можно потестировать:
* Скомпилировать и запустить тесты.
  * Для этого нужен Google Test. Под Debian сначала ставится `libgtest-dev`, потом в `/usr/src` делается `sudo cmake .`, `sudo make`, получившиеся библиотеки `libgtest*.a` копируются в `/usr/lib`. Для 32-битных версий надо запускать `sudo make clean`, `sudo cmake -DCMAKE_CXX_FLAGS=-m32 .` , `sudo make`, скопировать версии в `/usr/lib32`
  * Тесты гоняют какую-то машинерию (юнит-тесты) и, собственно, твои исходные тесты.
* Запустить приложение
* Можно включить в `Makefile` строчку 25 и появится некоторая куча отладочного вывода по поводу того, кто и что посылает. При этом надо `make clean && make` - от `Makefile` зависимости у меня не стоят.
* Можно сделать `tcpdump`.

Что замечено:
* При локальном тестировании в `netns` тесты проходят, приложение тоже работает. Это если 5% потерь и 5% переупорядочиваний.
* Работает причём намного шустрее TCP, но оно и понятно - я захардкодил перепосылки через каждые 100мс, а у TCP таймауты порядка десятков секунд.
* Если поставить 50% потерь и 50% переупорядочиваний, то приложение всё ещё работает.

Как устроен код:
* Удобнее всего, конечно, не читать :)
* `inc/utils`, `au_stream_addr_map.h` и `src/retrier.cpp` - это какие-то вещи в себе, их можно читать отдельно от всего.
* Юнит-тесты (в основном тестируются `utils/*`) живут в `test_*`
* Всё самое интересное происходит в `au_stream_*`
* `au_stream_socket.h` - внешний интерфейс для сокетов. Так как сокеты должны обрабатываться и в каком-то общем потоке (который слушает IP-пакеты), и в пользовательском коде, владельца установить не представляется возможным. Выход - `shared_ptr` на реализацию сокета. В целом файл несодержателен.
* `au_stream_socket_impl.h` - все основные определения:
  * `messages_broker` - слушает IP-пакеты, распределяет их по серверным сокетами и обычным. Синглтон.
  * `listener_impl` - серверный сокет. Создаётся от порта, привязывается к брокеру (кем-то конкретным, я не хотел `shared_ptr_from_this`). По сути представляет собой очередь клиентов, ничего более содержательного в нём нет. Вероятно, его можно вообще заменить на `locking_queue`, но она совсем недавно появилась.
  * `connection_impl` - клиентский сокет. Создаётся по паре "локальный адрес, удалённый адрес", умеет обрабатывать пакеты, начинать/завершать соединения и посылать/получать данные (последние две функции блокируются, если буфер отправки полный/получения пустой).
* `au_stream_socket_protocol.h` - немного определений из области протокола. В целом можно было бы объединить с `au_stream_socket_impl.h`.
* `au_stream_socket_impl.cpp` - тут исторически лежит почти весь брокер (кроме обработки входящих пакетов), серверный сокет и пара простых функций от клиентского. Никакого протокола тут нет, всё довольно техническое.
* `au_stream_socket_protocol.cpp` - самое мясо протокола: (де)сериализация пакетов, обработка входящих пакетов, переходы по состояниям, накопление-отправка-переотправка данных.
